### PR TITLE
Add update testing on postgres 10

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -80,7 +80,7 @@ services:
         DB_TYPE: mysql
 
   postgres:
-    image: postgres:9.4
+    image: ${POSTGRES_IMAGE=postgres:9.4}
     environment:
       - POSTGRES_USER=owncloud
       - POSTGRES_PASSWORD=owncloud
@@ -110,3 +110,9 @@ matrix:
     - mysql
     - postgres
     - oracle
+
+  include:
+    - FROM: 8.2.11
+      TO: daily-master-qa
+      DB_TYPE: postgres
+      POSTGRES_IMAGE: postgres:10.3


### PR DESCRIPTION
stable10 is not yet ready for postgres 10 - run following command to see the trouble:

```
FROM=8.2.11 TO=daily-stable10-qa DB_TYPE=postgres POSTGRES_IMAGE=postgres:10.3 drone exec

....


[upgrade-test:L51:19s] 2018-05-02T10:57:56+00:00 Repair info: App was not updated: provisioning_api
[upgrade-test:L52:19s] 2018-05-02T10:57:56+00:00 Updating database schema
[postgres:L58:37s] 2018-05-02 10:57:56.977 UTC [92] ERROR:  column "min_value" does not exist at character 8
[postgres:L59:37s] 2018-05-02 10:57:56.977 UTC [92] STATEMENT:  SELECT min_value, increment_by FROM "oc_storages_numeric_id_seq"
[upgrade-test:L53:19s] 2018-05-02T10:57:56+00:00 Doctrine\DBAL\Exception\InvalidFieldNameException: An exception occurred while executing 'SELECT min_value, increment_by FROM "oc_storages_numeric_id_seq"':
[upgrade-test:L54:19s] 
[upgrade-test:L55:19s] SQLSTATE[42703]: Undefined column: 7 ERROR:  column "min_value" does not exist
[upgrade-test:L56:19s] LINE 1: SELECT min_value, increment_by FROM "oc_storages_numeric_id_...
[upgrade-test:L57:19s]                ^
[upgrade-test:L58:19s] 2018-05-02T10:57:56+00:00 Update failed
[upgrade-test:L59:19s] 2018-05-02T10:57:56+00:00 Maintenance mode is kept active
[upgrade-test:L60:19s] 2018-05-02T10:57:56+00:00 Reset log level
2018/05/02 12:57:59 drone_step_2 : exit code 5
