### PR TITLE
show version information 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -44,8 +44,10 @@ pipeline:
     pull: true
     commands:
       - cd owncloud
+      - cat version.php
       - ls | grep -v data | grep -v config | xargs rm -rf
       - tar -jxf /drone/src/owncloud-${TO}.tar.bz2 -C /drone/src
+      - cat version.php
       - php ./occ up
 
   run-phpunit:


### PR DESCRIPTION
When running the nightly upgrade testing, we want to know what version was used to easier be able to track down issues