### PR TITLE
Disable template editor

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,6 +38,7 @@ pipeline:
       - php ./occ app:disable files_videoplayer
       - php ./occ app:disable files_videoviewer
       - php ./occ app:disable updater
+      - php ./occ app:disable templateeditor
 
   upgrade-test:
     image: owncloudci/php:7.1


### PR DESCRIPTION
There is an incompatibility warning that makes the testing fail.

Fixes https://github.com/owncloud/update-testing/issues/15

If we do want to test the process with incompatibilities or offline mode, need to be adressed separately: https://github.com/owncloud/update-testing/issues/8