### PR TITLE
Add 10.2 series to update testing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -128,15 +128,6 @@ matrix:
       TO: daily-master-qa
       DB_TYPE: oracle
     - FROM: 10.0.4
-      TO: daily-stable10-qa
-      DB_TYPE: mysql
-    - FROM: 10.0.4
-      TO: daily-stable10-qa
-      DB_TYPE: postgres
-    - FROM: 10.0.4
-      TO: daily-stable10-qa
-      DB_TYPE: oracle
-    - FROM: 10.0.4
       TO: daily-master-qa
       DB_TYPE: mysql
     - FROM: 10.0.4

--- a/.drone.yml
+++ b/.drone.yml
@@ -154,6 +154,15 @@ matrix:
     - FROM: 10.1.0
       TO: daily-master-qa
       DB_TYPE: oracle
+    - FROM: 10.2.0
+      TO: daily-master-qa
+      DB_TYPE: mysql
+    - FROM: 10.2.0
+      TO: daily-master-qa
+      DB_TYPE: postgres
+    - FROM: 10.2.0
+      TO: daily-master-qa
+      DB_TYPE: oracle
 
 #   Needs to be adressed in core https://github.com/owncloud/core/issues/33187
 #    - FROM: 8.2.11


### PR DESCRIPTION
Also start testing upgrades vom 10.2 to latest version.

## Motivation

It makes sense to test upgrading from the latest minor version to the current development version to see if I minor version series has issues upgrading to the current development/future release

Branch is based on top of https://github.com/owncloud/update-testing/pull/25 to avoid falures