### PR TITLE
Create apps-external from 10.2 onwards

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -63,6 +63,7 @@ pipeline:
     pull: true
     environment:
       - DB_TYPE=${DB_TYPE}
+      - EXTRA_APPS_PATHS_DIR=${EXTRA_APPS_PATHS_DIR}
     commands:
       - cd owncloud
       - ../.drone/install-server.sh
@@ -87,7 +88,7 @@ pipeline:
     commands:
       - cd owncloud
       - cat version.php
-      - ls | grep -v data | grep -v config | xargs rm -rf
+      - ls | grep -v data | grep -v config | grep -v apps-external | xargs rm -rf
       - tar -jxf /drone/src/owncloud-${TO}.tar.bz2 -C /drone/src
       - cat version.php
       - php ./occ up
@@ -217,38 +218,47 @@ matrix:
       TO: daily-master-qa
       DB_TYPE: mysql
       MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
     - FROM: 10.2.0
       TO: daily-master-qa
       DB_TYPE: postgres
       MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
     - FROM: 10.2.0
       TO: daily-master-qa
       DB_TYPE: oracle
       MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
     - FROM: 10.3.0
       TO: daily-master-qa
       DB_TYPE: mysql
       MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
     - FROM: 10.3.0
       TO: daily-master-qa
       DB_TYPE: postgres
       MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
     - FROM: 10.3.0
       TO: daily-master-qa
       DB_TYPE: oracle
       MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
     - FROM: 10.4.0
       TO: daily-master-qa
       DB_TYPE: mysql
       MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
     - FROM: 10.4.0
       TO: daily-master-qa
       DB_TYPE: postgres
       MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
     - FROM: 10.4.0
       TO: daily-master-qa
       DB_TYPE: oracle
       MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
 
 #   Needs to be adressed in core https://github.com/owncloud/core/issues/33187
 #    - FROM: 8.2.11

--- a/.drone/install-server.sh
+++ b/.drone/install-server.sh
@@ -39,6 +39,12 @@ fi
 # Cleanup data  / config
 rm -rf ${DATA_DIRECTORY} config/config.php
 
+# Create any needed "default" apps_paths directory like apps-external
+if [ -n "${EXTRA_APPS_PATHS_DIR}" ]
+then
+  mkdir -p ${EXTRA_APPS_PATHS_DIR}
+fi
+
 PLUGIN_DB_TIMEOUT=600
 
 plugin_wait_for_oracle() {


### PR DESCRIPTION
Fixes issue #33 

For updates from core 10.2 or later, create the `apps-external` directory as part of the initial installation, and preserve it when installing the upgrade. This simulates what could be the workflow when upgrading, and leaves the upgraded system in a state where it is working and can run the PHP unit tests.