### PR TITLE
Use PHP 7.2 for all updating

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -83,7 +83,7 @@ pipeline:
         MAJOR_VERSION: v10
 
   upgrade-test:
-    image: owncloudci/php:7.1
+    image: owncloudci/php:7.2
     pull: true
     commands:
       - cd owncloud
@@ -94,7 +94,7 @@ pipeline:
       - php ./occ up
 
   run-phpunit:
-    image: owncloudci/php:7.1
+    image: owncloudci/php:7.2
     pull: true
     commands:
       - cd owncloud


### PR DESCRIPTION
PHP 7.1 has been dropped in core master as part of the upcoming 10.5.0 release.

Do the updates and run the unit tests with PHP 7.2

Note: the initial install of ownCloud 8, 9 or 10 is still using PHP 7.0 or 7.1 because that was the version of PHP that was supported back then. e.g. https://github.com/owncloud/core/blob/v10.0.4/index.php 10.0.4 only supported up to PHP 7.1. Anyone running 10.0.4 nowadays would be using PHP 7.1. To upgrade to upcoming 10.5.0 they will have to do something like:
- put the system into maintenance mode
- install a newer PHP version 7.*
- put the new version of ownCloud code in place
- `occ upgrade`
- take the system out of maintenance mode

Or some other strategy - e.g.
- upgrade to 10.4.1 (staying on PHP 7.1)
- change to PHP 7.2 or 7.3
- upgrade from 10.4.1 to 10.5.0