### PR TITLE
Add update tests from recent core 10.* releases

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,6 +23,18 @@ pipeline:
       matrix:
         MAJOR_VERSION: v8orv9
 
+  owncloud-download-v10old:
+    image: owncloudci/php:7.1
+    pull: true
+    commands:
+      - pwd
+      - rm -rf owncloud
+      - .drone/download.sh ${FROM} ${TO}
+      - tar -jxf owncloud-${FROM}.tar.bz2 -C /drone/src
+    when:
+      matrix:
+        MAJOR_VERSION: v10old
+
   owncloud-download-v10:
     image: owncloudci/php:7.2
     pull: true
@@ -57,6 +69,30 @@ pipeline:
     when:
       matrix:
         MAJOR_VERSION: v8orv9
+
+  install-from-version-v10old:
+    image: owncloudci/php:7.1
+    pull: true
+    environment:
+      - DB_TYPE=${DB_TYPE}
+      - EXTRA_APPS_PATHS_DIR=${EXTRA_APPS_PATHS_DIR}
+    commands:
+      - cd owncloud
+      - ../.drone/install-server.sh
+      - more config/config.php
+      - php -f cron.php
+      - php -f cron.php
+      - php ./occ app:disable activity
+      - php ./occ app:disable files_pdfviewer
+      - php ./occ app:disable files_texteditor
+      - php ./occ app:disable gallery
+      - php ./occ app:disable files_videoplayer
+      - php ./occ app:disable files_videoviewer
+      - php ./occ app:disable updater
+      - php ./occ app:disable templateeditor
+    when:
+      matrix:
+        MAJOR_VERSION: v10old
 
   install-from-version-v10:
     image: owncloudci/php:7.2
@@ -181,15 +217,15 @@ matrix:
     - FROM: 10.0.4
       TO: daily-master-qa
       DB_TYPE: mysql
-      MAJOR_VERSION: v10
+      MAJOR_VERSION: v10old
     - FROM: 10.0.4
       TO: daily-master-qa
       DB_TYPE: postgres
-      MAJOR_VERSION: v10
+      MAJOR_VERSION: v10old
     - FROM: 10.0.4
       TO: daily-master-qa
       DB_TYPE: oracle
-      MAJOR_VERSION: v10
+      MAJOR_VERSION: v10old
     - FROM: 10.0.10
       TO: daily-master-qa
       DB_TYPE: mysql

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ pipeline:
         MAJOR_VERSION: v8orv9
 
   owncloud-download-v10:
-    image: owncloudci/php:7.1
+    image: owncloudci/php:7.2
     pull: true
     commands:
       - pwd
@@ -59,7 +59,7 @@ pipeline:
         MAJOR_VERSION: v8orv9
 
   install-from-version-v10:
-    image: owncloudci/php:7.1
+    image: owncloudci/php:7.2
     pull: true
     environment:
       - DB_TYPE=${DB_TYPE}
@@ -255,6 +255,51 @@ matrix:
       MAJOR_VERSION: v10
       EXTRA_APPS_PATHS_DIR: apps-external
     - FROM: 10.4.0
+      TO: daily-master-qa
+      DB_TYPE: oracle
+      MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
+    - FROM: 10.5.0
+      TO: daily-master-qa
+      DB_TYPE: mysql
+      MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
+    - FROM: 10.5.0
+      TO: daily-master-qa
+      DB_TYPE: postgres
+      MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
+    - FROM: 10.5.0
+      TO: daily-master-qa
+      DB_TYPE: oracle
+      MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
+    - FROM: 10.6.0
+      TO: daily-master-qa
+      DB_TYPE: mysql
+      MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
+    - FROM: 10.6.0
+      TO: daily-master-qa
+      DB_TYPE: postgres
+      MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
+    - FROM: 10.6.0
+      TO: daily-master-qa
+      DB_TYPE: oracle
+      MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
+    - FROM: 10.7.0
+      TO: daily-master-qa
+      DB_TYPE: mysql
+      MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
+    - FROM: 10.7.0
+      TO: daily-master-qa
+      DB_TYPE: postgres
+      MAJOR_VERSION: v10
+      EXTRA_APPS_PATHS_DIR: apps-external
+    - FROM: 10.7.0
       TO: daily-master-qa
       DB_TYPE: oracle
       MAJOR_VERSION: v10


### PR DESCRIPTION
1a) change 10.* upgrade steps to use PHP 7.2. Later 10.* releases no longer support PHP 7.1. For sites that are upgrading, for example, from 10.1 to 10.7, they really have to update PHP  to at least 7.2 first anyway.

1b) add pipelines for upgrade from 10.5 10.6 10.7

2) v10.0.4 did not support PHP 7.2. Make that still install with PHP 7.1 and then do the actual upgrade with PHP 7.2