### PR TITLE
Check for notification app enabled

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -78,6 +78,7 @@ pipeline:
       - php ./occ app:disable files_videoviewer
       - php ./occ app:disable updater
       - php ./occ app:disable templateeditor
+      - php ./occ app:disable notifications
     when:
       matrix:
         MAJOR_VERSION: v8orv9
@@ -102,6 +103,7 @@ pipeline:
       - php ./occ app:disable files_videoviewer
       - php ./occ app:disable updater
       - php ./occ app:disable templateeditor
+      - php ./occ app:disable notifications
     when:
       matrix:
         MAJOR_VERSION: v10-71
@@ -126,6 +128,7 @@ pipeline:
       - php ./occ app:disable files_videoviewer
       - php ./occ app:disable updater
       - php ./occ app:disable templateeditor
+      - php ./occ app:disable notifications
     when:
       matrix:
         MAJOR_VERSION: v10-72
@@ -150,6 +153,7 @@ pipeline:
       - php ./occ app:disable files_videoviewer
       - php ./occ app:disable updater
       - php ./occ app:disable templateeditor
+      - php ./occ app:disable notifications
     when:
       matrix:
         MAJOR_VERSION: v10


### PR DESCRIPTION
Fixes issue https://github.com/owncloud/update-testing/issues/41

The notifications app unit tests were being run in CI, even though the notifications app is not part of the core repo. This PR disables the notifications app in CI, so that those unit tests do not run. That is the same as is already done for other apps that are not part of the core repo.