### PR TITLE
Upgrade 9.0 to 9.1 to 10

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,6 +23,18 @@ pipeline:
       matrix:
         MAJOR_VERSION: v8orv9
 
+  owncloud-download-v9multi:
+    image: owncloudci/php:7.0
+    pull: true
+    commands:
+      - pwd
+      - rm -rf owncloud
+      - .drone/download.sh ${FROM} ${TO} ${VIA}
+      - tar -jxf owncloud-${FROM}.tar.bz2 -C /drone/src
+    when:
+      matrix:
+        MAJOR_VERSION: v9multi
+
   owncloud-download-v10-71:
     image: owncloudci/php:7.1
     pull: true
@@ -82,6 +94,30 @@ pipeline:
     when:
       matrix:
         MAJOR_VERSION: v8orv9
+
+  install-from-version-v9multi:
+    image: owncloudci/php:7.0
+    pull: true
+    environment:
+      - DB_TYPE=${DB_TYPE}
+    commands:
+      - cd owncloud
+      - ../.drone/install-server.sh
+      - more config/config.php
+      - php -f cron.php
+      - php -f cron.php
+      - php ./occ app:disable activity
+      - php ./occ app:disable files_pdfviewer
+      - php ./occ app:disable files_texteditor
+      - php ./occ app:disable gallery
+      - php ./occ app:disable files_videoplayer
+      - php ./occ app:disable files_videoviewer
+      - php ./occ app:disable updater
+      - php ./occ app:disable templateeditor
+      - php ./occ app:disable notifications
+    when:
+      matrix:
+        MAJOR_VERSION: v9multi
 
   install-from-version-v10-71:
     image: owncloudci/php:7.1
@@ -158,6 +194,22 @@ pipeline:
       matrix:
         MAJOR_VERSION: v10
 
+  upgrade-via:
+    image: owncloudci/php:7.0
+    pull: true
+    commands:
+      - cd owncloud
+      - cat version.php
+      - ls | grep -v data | grep -v config | grep -v apps-external | xargs rm -rf
+      - tar -jxf /drone/src/owncloud-${VIA}.tar.bz2 -C /drone/src
+      - cat version.php
+      - php ./occ up
+      - php -f cron.php
+      - php -f cron.php
+    when:
+      matrix:
+        MAJOR_VERSION: v9multi
+
   upgrade-test:
     image: owncloudci/php:7.4
     pull: true
@@ -231,13 +283,15 @@ matrix:
       DB_TYPE: oracle
       MAJOR_VERSION: v8orv9
     - FROM: 9.0.11
+      VIA: 9.1.8
       TO: daily-master-qa
       DB_TYPE: mysql
-      MAJOR_VERSION: v8orv9
+      MAJOR_VERSION: v9multi
     - FROM: 9.0.11
+      VIA: 9.1.8
       TO: daily-master-qa
       DB_TYPE: postgres
-      MAJOR_VERSION: v8orv9
+      MAJOR_VERSION: v9multi
     - FROM: 9.0.11
       TO: daily-master-qa
       DB_TYPE: oracle

--- a/.drone/download.sh
+++ b/.drone/download.sh
@@ -6,7 +6,6 @@ TO_VERSION=$2
 FROM=owncloud-$FROM_VERSION.tar.bz2
 TO=owncloud-$TO_VERSION.tar.bz2
 
-
 if [ ! -f $FROM ]; then
   # Look in download.owncloud.com/server for the tarball
   # All official tarballs will be found there
@@ -33,6 +32,28 @@ if [ ! -f $TO ]; then
   fi
 else
   echo "Reuse existing $TO"
+fi
+
+if [ ! -z "$3" ]; then
+  VIA_VERSION=$3
+  VIA=owncloud-$VIA_VERSION.tar.bz2
+  if [ ! -f $VIA ]; then
+    # Look in download.owncloud.com/server for the tarball
+    # All official tarballs will be found there
+    wget -nv http://download.owncloud.com/server/daily/$VIA || true
+    if [ ! -f $VIA ]; then
+      wget -nv http://download.owncloud.com/server/testing/$VIA || true
+    fi
+    if [ ! -f $VIA ]; then
+      wget -nv http://download.owncloud.com/server/stable/$VIA || true
+    fi
+  else
+    echo "Reuse existing $VIA"
+  fi
+  if [ ! -f $VIA ]; then
+    echo "Could not download $VIA"
+    exit 1
+  fi
 fi
 
 if [ ! -f $FROM ]; then


### PR DESCRIPTION
This PR adjusts the upgrade pipelines so that the pipelines that test upgrades from 9.0.11 to current daily-master with mysql and pgsql databases will:
- install 9.0.11
- upgrade to 9.1.8
- run cron.php to make sure that background jobs happened
- upgrade to current daily-master
- run unit tests

Adding the step(s) to first upgrade to 9.1.8 gets the unit tests all passing. This is the recommended upgrade path anyway - always first upgrade to the latest minor version or a major version series, then upgrade to the next major version.

Fixes #48 